### PR TITLE
BOBUH-10964 При переключении ветки затираются незакомиченные изменения

### DIFF
--- a/web_bb_tools/__init__.py
+++ b/web_bb_tools/__init__.py
@@ -110,8 +110,6 @@ def command_checkout(all_packages, *args, **kwargs):
             getattr(origin.refs, branch_name)
         ).checkout()
 
-        repo.head.reset(index=True, working_tree=True)
-
     command_info(all_packages)
 
 


### PR DESCRIPTION
**Последовательность действий**
Допустим мы на ветке test. Делаем любые изменения, не коммитим.
`python web_bb.py co dev`
Если изменения такие, что git checkout не будет ругаться, то они будут удалены.

**Причина**
git reset --hard после checkout